### PR TITLE
Fix typo in main.scss

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -564,7 +564,7 @@ $menu-height: 70px;
 		float: left;
 		height: $size;
 		margin-right: 30px;
-		overfow: hidden;
+		overflow: hidden;
 		text-align: center;
 		width: $size;
 


### PR DESCRIPTION
Small typo in the .picture class, "overfow" instead of "overflow"